### PR TITLE
Fix overflowing charts in firefox

### DIFF
--- a/src/main/webapp/styles/dashboard.css
+++ b/src/main/webapp/styles/dashboard.css
@@ -157,6 +157,7 @@ body {
 }
 .chart-container .chart > * {
   display: block;
+  height: inherit;
 }
 /* Current stats */
 #current-stats {


### PR DESCRIPTION
![screen shot 2014-04-23 at 11 34 54 am](https://cloud.githubusercontent.com/assets/860492/2779610/b694ffa2-cafd-11e3-9281-1f9e309f77d2.png)

Small bug in the existing css in firefox where the charts would overflow the containers.

Double-checked chrome rendering after fix, should be fine in both browsers.
