### PR TITLE
Truncate minutes to prevent situations such as 1h60m.

### DIFF
--- a/src/main/scala/com/bizo/crucible/survivor/scoring/impl/TimeWeightedOpenClosedScoring.scala
+++ b/src/main/scala/com/bizo/crucible/survivor/scoring/impl/TimeWeightedOpenClosedScoring.scala
@@ -170,6 +170,6 @@ class TimeWeightedOpenClosedScoring(
     val wholeHours = hours.toInt
     val minutes = (hours - wholeHours) * 1.hour.toMinutes
 
-    f"${wholeHours}h${minutes.toInt}%02.0fm"
+    f"${wholeHours}h${minutes.toInt}%2dm"
   }
 }

--- a/src/main/scala/com/bizo/crucible/survivor/scoring/impl/TimeWeightedOpenClosedScoring.scala
+++ b/src/main/scala/com/bizo/crucible/survivor/scoring/impl/TimeWeightedOpenClosedScoring.scala
@@ -170,6 +170,6 @@ class TimeWeightedOpenClosedScoring(
     val wholeHours = hours.toInt
     val minutes = (hours - wholeHours) * 1.hour.toMinutes
 
-    f"${wholeHours}h${minutes}%02.0fm"
+    f"${wholeHours}h${minutes.toInt}%02.0fm"
   }
 }


### PR DESCRIPTION
This happened today on the board. You can reproduce by calling `formatHours(1.999)`.